### PR TITLE
Add exception throwing assertions

### DIFF
--- a/src/test/scala/resource/TestManagedResource.scala
+++ b/src/test/scala/resource/TestManagedResource.scala
@@ -114,6 +114,17 @@ class TestManagedResource {
      assertFalse("Failed to close resource", r.isOpened)
    }
 
+   @Test(expected=classOf[IllegalStateException])
+   def mustThrowCloseException() {
+     val r = new ThrowingFakeResource()
+     assertFalse("Failed to begin closed!", r.isOpened)
+     val mr = managed(r)
+     assertFalse("Creating managed resource opens the resource!", r.isOpened)
+     for(r <- mr) {
+       assertTrue("Failed to open resource", r.isOpened)
+     }
+   }
+
    @Test
    def mustThrowClosureExceptionIfBothClosureAndCloseThrow() {
      val r = new ThrowingFakeResource()


### PR DESCRIPTION
Hi Josh,

Here are two commits for checking ARM in the face of exceptions.  The first commit passes the unit tests because ARM works, but the second fails because close()'s exception is not propagated to the caller if the body doesn't throw, which is different than how JDK7's try-with-resources works.  See http://docs.oracle.com/javase/specs/jls/se7/html/jls-14.html#jls-14.20.3

BTW, is there a better place to discuss this than in a pull request?

Blair
