### PR TITLE
Use javax.transaction" % "jta" % "1.1" - fixes #16

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -82,7 +82,7 @@ object ArmDef extends Build {
     "junit" % "junit" % "4.5" % "test",
     "com.novocode" % "junit-interface" % "0.7" % "test->default",
     "org.apache.derby" % "derby" % "10.5.3.0_1" % "test",
-    "javax.transaction" % "jta" % "1.0.1B" % "provided"
+    "javax.transaction" % "jta" % "1.1" % "provided"
   )
 
   


### PR DESCRIPTION
JTA 1.0.1B is missing from Maven Central, so best not to depend on it:

http://repo1.maven.org/maven2/javax/transaction/jta/1.0.1B/

https://github.com/jsuereth/scala-arm/issues/16
