### PR TITLE
Fix build to use released scala-continuations artifacts for Scala 2.11

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -14,8 +14,8 @@ object ArmDef extends Build {
     organization := "com.jsuereth",
     name := "scala-arm",
     version := "1.4-SNAPSHOT",
-    scalaVersion := "2.10.3",
-    crossScalaVersions := Seq("2.9.3", "2.10.3"),
+    scalaVersion := "2.11.0",
+    crossScalaVersions := Seq("2.9.3", "2.10.4", "2.11.0"),
     resolvers += "java.net repo" at "http://download.java.net/maven/2/",
     libraryDependencies ++= dependencies,
     autoCompilerPlugins := true,
@@ -74,8 +74,8 @@ object ArmDef extends Build {
     CrossVersion.partialVersion(scalaVersion.value) match {
       // if scala 2.11+ is used, add dependency on scala-xml module
       case Some((2, scalaMajor)) if scalaMajor >= 11 =>
-        Seq(compilerPlugin("org.scala-lang.plugins" %% "scala-continuations-plugin" % "1.0.0"),
-          "org.scala-lang.plugins" %% "scala-continuations-library" % "1.0.0")
+        Seq(compilerPlugin("org.scala-lang.plugins" % "scala-continuations-plugin_2.11.0" % "1.0.1"),
+          "org.scala-lang.plugins" %% "scala-continuations-library" % "1.0.1")
       case _ =>
         Seq(compilerPlugin("org.scala-lang.plugins" % "continuations" % scalaVersion.value))
     }


### PR DESCRIPTION
Looks like version 1.0.0 of the scala-continuations-plugin was never published to Maven Central:

http://search.maven.org/#search%7Cga%7C1%7Corg.scala-lang.plugins

...and note also that the published coordinate for "scala-continuations-plugin" includes the minor binary version number, ie "2.11.0", not "2.11".

"org.scala-lang.plugins" % "scala-continuations-plugin_2.11.0" % "1.0.1"

http://search.maven.org/#artifactdetails%7Corg.scala-lang.plugins%7Cscala-continuations-plugin_2.11.0%7C1.0.1%7Cbundle
