### PR TITLE
Tweak dependency on 2.11+ continuations plugins

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -102,7 +102,7 @@ object ArmDef extends Build {
     CrossVersion.partialVersion(scalaVersion.value) match {
       // if scala 2.11+ is used, add dependency on scala-xml module
       case Some((2, scalaMajor)) if scalaMajor >= 11 =>
-        Seq(compilerPlugin("org.scala-lang.plugins" % "scala-continuations-plugin_2.11.0" % "1.0.1"),
+        Seq(compilerPlugin("org.scala-lang.plugins" % ("scala-continuations-plugin_" + scalaVersion.value) % "1.0.1"),
           "org.scala-lang.plugins" %% "scala-continuations-library" % "1.0.1")
       case _ =>
         Seq(compilerPlugin("org.scala-lang.plugins" % "continuations" % scalaVersion.value))


### PR DESCRIPTION
In an attempt to fix:

  https://jenkins-dbuild.typesafe.com:8499/job/Community-2.11.x/138/consoleFull
