### PR TITLE
Use ManagedResource as Future

### DIFF
--- a/src/main/scala/resource/ManagedResource.scala
+++ b/src/main/scala/resource/ManagedResource.scala
@@ -16,6 +16,7 @@ package resource
 import _root_.scala.collection.Traversable
 import _root_.scala.collection.Iterator
 import _root_.scala.Either
+import _root_.scala.concurrent.{ ExecutionContext, Future }
 import util.continuations.{suspendable, cps}
 
 /**
@@ -97,6 +98,14 @@ trait ManagedResource[+R] {
    * @return A Traversable of elements of type B. 
    */
   def toTraversable[B](implicit ev: R <:< TraversableOnce[B]): Traversable[B]
+
+  /**
+   * This method creates a Future that will perform operations  
+   * within the context of an "open" resource. 
+   * Execution of Future will hold error as Failure, otherwise result will be 
+   * inside a Success.
+   */
+  def toFuture(implicit context: ExecutionContext): Future[R]
 
   /**
    * Creates a new resource that is the aggregation of this resource and another.

--- a/src/main/scala/resource/ManagedResourceOperations.scala
+++ b/src/main/scala/resource/ManagedResourceOperations.scala
@@ -16,6 +16,7 @@ package resource
 import _root_.scala.collection.Traversable
 import _root_.scala.collection.TraversableOnce
 import _root_.scala.util.continuations.{cps,shift, suspendable}
+import _root_.scala.concurrent.{ ExecutionContext, Future }
 /**
  * This class implements all ManagedResource methods except acquireFor.   This allows all new ManagedResource
  * implementations to be defined in terms of the acquireFor method.
@@ -30,6 +31,9 @@ trait ManagedResourceOperations[+R] extends ManagedResource[R] { self =>
       override protected def internalForeach[U](resource: R, g : B => U) : Unit = 
         ev(resource).foreach(g) 
     }
+
+  def toFuture(implicit context: ExecutionContext): Future[R] = 
+    Future(acquireAndGet(identity))
 
   override def map[B](f : R => B): ExtractableManagedResource[B] =
     new DeferredExtractableManagedResource(self, f)


### PR DESCRIPTION
It may be useful to have a convinient function to use managed resource as `Future`.