### PR TITLE
Ensure that all exceptions are captured and returned to the callee

### DIFF
--- a/src/main/scala/resource/ExtractableManagedResource.scala
+++ b/src/main/scala/resource/ExtractableManagedResource.scala
@@ -46,5 +46,7 @@ trait ExtractableManagedResource[+A] extends ManagedResource[A] {
    *        An either where the left hand side is the currently contained resource unless exceptions, in which case
    *        the right hand side will contain the sequence of throwable encountered.
    */
-  def either: Either[Seq[Throwable], A]
+  def either: ExtractedEither[Seq[Throwable], A]
 }
+
+case class ExtractedEither[+A, +B](either: Either[A, B])

--- a/src/main/scala/resource/ManagedResource.scala
+++ b/src/main/scala/resource/ManagedResource.scala
@@ -97,7 +97,7 @@ trait ManagedResource[+R] {
    * @return    The result of the function (right) or the list of exceptions seen during the processing of the
    *            resource (left).
    */
-  def acquireFor[B](f: R => B): Either[List[Throwable], B]
+  def acquireFor[B](f: R => B): ExtractedEither[List[Throwable], B]
 
   /**
    * This method creates a Traversable in which all performed methods are done within the context of an "open"

--- a/src/main/scala/resource/ManagedResourceOperations.scala
+++ b/src/main/scala/resource/ManagedResourceOperations.scala
@@ -40,8 +40,8 @@ trait ManagedResourceOperations[+R] extends ManagedResource[R] { self =>
   
   override def flatMap[B](f : R => ManagedResource[B]): ManagedResource[B] = 
     new ManagedResourceOperations[B] {
-      override def acquireFor[C](f2 : B => C) : Either[List[Throwable], C] = {
-	    self.acquireFor(r => f(r).acquireFor(f2)).fold(x => Left(x), x => x)
+      override def acquireFor[C](f2 : B => C) : ExtractedEither[List[Throwable], C] = {
+	    self.acquireFor(r => f(r).acquireFor(f2)).fold(x => ExtractedEither(Left(x)), x => x)
 	  }
 	  override def toString = "FlattenedManagedResource[?](...)"
     }

--- a/src/main/scala/resource/package.scala
+++ b/src/main/scala/resource/package.scala
@@ -61,7 +61,7 @@ package object resource {
       val r1 = toReturn
       val r2: ManagedResource[A] = itr.next
       toReturn = new ManagedResource[Seq[A]] with ManagedResourceOperations[Seq[A]] {
-        override def acquireFor[B](f : Seq[A] => B) : Either[List[Throwable], B] = r1.acquireFor {
+        override def acquireFor[B](f : Seq[A] => B) : ExtractedEither[List[Throwable], B] = r1.acquireFor {
           r1seq =>
             r2.acquireAndGet { r2item =>
               f( r2item :: r1seq.toList)
@@ -71,5 +71,8 @@ package object resource {
     }
     toReturn
   }
+
+  import scala.language.implicitConversions
+  implicit def extractedEitherToEither[A, B](extracted: ExtractedEither[A, B]) : Either[A, B] = extracted.either
 }
 


### PR DESCRIPTION
Previously when either nesting managed resources or using `and` to compose them, if an exception occurred in the close method of the outer managed resource, then any exceptions produced by the inner managed resource were lost.

1. The tests that I have added clearly show the issue

2. I have produced a fix; There are maybe other ways to fix this but the approach I settled on was pragmatic and minimally intrusive as far as I could figure out. Happy to discuss...