### PR TITLE
Update shared resource to use atomic references instead of locks.

### DIFF
--- a/src/main/scala/resource/SharedResource.scala
+++ b/src/main/scala/resource/SharedResource.scala
@@ -1,0 +1,59 @@
+package resource
+
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.AtomicInteger
+
+final class SharedResource[A : Resource : Manifest](opener: => A) extends AbstractManagedResource[A] {
+	private val resource = implicitly[Resource[A]]
+	// A referencing counting atomic variable we use to "guard" this resource.
+	// Currently, we spin-lock accessing this ref because we don't expect opening to block a thread for very long.
+	private val ref = new AtomicReference[Option[A]](None)
+	private val count = new AtomicInteger(0)
+
+	protected def open: A = {
+		val myCount = count.addAndGet(1)
+		// If we win the race, we construct the resource
+		if (myCount == 1) {
+			// We must construct the reference
+			// We may want to CAS here and fail if we're inconsistent.
+			val r = opener
+			ref.lazySet(Some(r))
+			resource open r
+		}
+		// Lazy spin to get the current value
+		def get(): A = 
+		   ref.get match {
+		     case Some(r) => r
+		     case None => 
+		       // TODO - backoff strategy
+		       Thread.`yield`()
+		       get()
+		   }
+		get()
+	}
+	protected def unsafeClose(handle: A, errors: Option[Throwable]): Unit = {
+		val cnt = count.decrementAndGet()
+		// TODO - Throw error if cnt reaches negative?
+		if (cnt == 0) {
+			// Mark the resource as closed, while we clean up behind the scenes.
+			// If the CAS fails, it means someone else has already opened the resource again.
+			ref.compareAndSet(Some(handle), None)
+			// Cleanup the resource
+			// TODO - We don't know if an error occurred on a different thread, so we need to figure out how to flag that.
+			//        We porbably need some kind of atomic reference of failure on a thread so we can call this appropriately.
+			errors match {
+              case None    => resource.close(handle)
+              case Some(t) => resource.closeAfterException(handle, t)
+            }
+		}
+
+	}
+
+  override protected def isFatal(t: Throwable): Boolean =
+    resource isFatalException t
+  override protected def isRethrown(t: Throwable): Boolean =
+    resource isRethrownException t
+  /* You cannot serialize resource and send them, so referential equality should be sufficient. */
+  override def hashCode(): Int = (resource.hashCode << 7) + super.hashCode + 13
+	override def toString = s"SharedResource[${implicitly[Manifest[A]]}]"
+}

--- a/src/main/scala/resource/package.scala
+++ b/src/main/scala/resource/package.scala
@@ -83,7 +83,7 @@ package object resource {
     * There is only one instance of the resource at the same time for all the users.
     * The instance will be closed once no user is still using it.
     */
-  def shared[A: Resource : Manifest](opener: => A): ManagedResource[A] = new SharedResource[A](opener)
+  def shared[A <: AnyRef : Resource : Manifest](opener: => A): ManagedResource[A] = new SharedResource[A](opener)
   
   import scala.language.implicitConversions
   implicit def extractedEitherToEither[A, B](extracted: ExtractedEither[A, B]) : Either[A, B] = extracted.either

--- a/src/main/scala/resource/package.scala
+++ b/src/main/scala/resource/package.scala
@@ -83,50 +83,8 @@ package object resource {
     * There is only one instance of the resource at the same time for all the users.
     * The instance will be closed once no user is still using it.
     */
-  def shared[A: Resource : Manifest](opener: => A): ManagedResource[A] = {
-    @volatile var sharedReference: Option[(Int, A)] = None
-    val lock = new AnyRef
-
-    def acquire = {
-      lock.synchronized {
-        val (referenceCount, sc) = sharedReference match {
-          case None =>
-            val r = opener
-            implicitly[Resource[A]].open(r)
-            (1, r)
-          case Some((oldReferenceCount, sc)) =>
-            (oldReferenceCount + 1, sc)
-        }
-        sharedReference = Some((referenceCount, sc))
-        sc
-      }
-    }
-
-    val resource = new Resource[A] {
-
-      override def close(r: A): Unit = {
-        lock.synchronized {
-          sharedReference match {
-            case Some((oldReferenceCount, sc)) =>
-              if (r != sc) {
-                throw new IllegalArgumentException
-              }
-              if (oldReferenceCount == 1) {
-                implicitly[Resource[A]].close(sc)
-                sharedReference = None
-              } else {
-                sharedReference = Some((oldReferenceCount - 1, sc))
-              }
-            case None =>
-              throw new IllegalStateException
-          }
-        }
-      }
-    }
-
-    new DefaultManagedResource[A](acquire)(resource, implicitly[Manifest[A]])
-  }
-
+  def shared[A: Resource : Manifest](opener: => A): ManagedResource[A] = new SharedResource[A](opener)
+  
   import scala.language.implicitConversions
   implicit def extractedEitherToEither[A, B](extracted: ExtractedEither[A, B]) : Either[A, B] = extracted.either
 }


### PR DESCRIPTION
Lockless would be ideal for these, but there's a lot of caveats in the implementation that need to be thought through, specifically "close after exception".

Review by: @Atry
