### PR TITLE
Move close operation out of synchronized block

### DIFF
--- a/src/main/scala/resource/package.scala
+++ b/src/main/scala/resource/package.scala
@@ -117,12 +117,13 @@ package object resource {
                 Some((oldReferenceCount - 1, sc))
               }
               sharedReference = newValue
+              newValue
             case None =>
               throw new IllegalStateException
           }
         }
         if (newValue.isEmpty) {
-          implicitly[Resource[A]].close(sc)
+          implicitly[Resource[A]].close(r)
         }
       }
     }


### PR DESCRIPTION
This change may enhance performance if close operation take a long time
