### PR TITLE
Resource instance for releasable types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+*/target

--- a/src/jekyll/resource.md
+++ b/src/jekyll/resource.md
@@ -28,10 +28,17 @@ Type classes in scala are encoded using implicit parameters.   Due to the mechan
     override def close(r : A) = r.close()
     override def toString = "Resource[{ def close() : Unit }]"
   }
+
   type ReflectiveDisposable = { def dispose() }
   implicit def reflectiveDisposableResource[A <: ReflectiveDisposable] = new Resource[A] {
     override def close(r : A) = r.dispose()
     override def toString = "Resource[{ def dispose() : Unit }]"
+  }
+
+  type ReflectiveReleasable = { def release() }
+  implicit def reflectiveReleasableResource[A <: ReflectiveReleasable] = new Resource[A] {
+    override def close(r : A) = r.release()
+    override def toString = "Resource[{ def release() : Unit }]"
   }
 {% endhighlight %}
 

--- a/src/test/scala/resource/TestUsing.scala
+++ b/src/test/scala/resource/TestUsing.scala
@@ -10,9 +10,7 @@ import org.junit.Assert._
 /**
  * Tests for the Using helpers.
  */
-class TestUsing {
-
-
+final class TestUsing {
   @Test
   def fileReaderWriter(): Unit = {
     val tmp = File.createTempFile("test", "txt")
@@ -89,6 +87,8 @@ class TestUsing {
   @Test
   def testGzipClose(): Unit = {
     val l = new GZIPOutputStream(new ByteArrayOutputStream())
+    println(s"x = ${implicitly[Resource[GZIPOutputStream]]}")
+
     managed(l).acquireFor { _ => }
     assertTrue("GZIPOutputStream was closed after write", streamClosed(l))
   }


### PR DESCRIPTION
Structural instance of `Resource` for releasable type (having a `release()` method).