### PR TITLE
Add type parameter to foreach.

### DIFF
--- a/src/main/scala/resource/ManagedResource.scala
+++ b/src/main/scala/resource/ManagedResource.scala
@@ -62,7 +62,7 @@ trait ManagedResource[+R] {
    *
    * @param f The function to apply against the raw resource.
    */
-  def foreach(f: R => Unit) : Unit
+  def foreach[U](f: R => U) : Unit
 
   /**
    * Acquires the resource for the Duration of a given function, The resource will automatically be opened and closed.

--- a/src/main/scala/resource/ManagedResourceOperations.scala
+++ b/src/main/scala/resource/ManagedResourceOperations.scala
@@ -50,7 +50,7 @@ trait ManagedResourceOperations[+R] extends ManagedResource[R] { self =>
 	  }
 	  override def toString = "FlattenedManagedResource[?](...)"
     }
-  override def foreach(f: R => Unit): Unit = acquireAndGet(f)
+  override def foreach[U](f: R => U): Unit = acquireAndGet(f)
   override def and[B](that: ManagedResource[B]) : ManagedResource[(R,B)] = resource.and(self,that)
 }
 


### PR DESCRIPTION
This allows calls to `foreach` to be made with side-effecting methods which nevertheless return a value (such as commons-io `IOUtils.copy`) without angering `-Ywarn-value-discard`.