### PR TITLE
Provide an implicit for AutoCloseable instead of Closeable

### DIFF
--- a/src/jekyll/resource.md
+++ b/src/jekyll/resource.md
@@ -44,4 +44,4 @@ Type classes in scala are encoded using implicit parameters.   Due to the mechan
 
 These two implicits allow users of the library to make use of any resource class that defines a close or dispose method.  The downside is that by using structural types, the close and dispose method will be invoked via reflection.
 
-The scala-arm library also provides default implicits for common resources used from the Scala library or the Java SDK.  In particular, anything that extends `java.io.Closeable` will *not* use reflection when closing the resource.  This type class is given slightly higher priority so it will be preferred to the reflective version when resolving implicits.
+The scala-arm library also provides default implicits for common resources used from the Scala library or the Java SDK.  In particular, anything that extends `java.lang.AutoCloseable` will *not* use reflection when closing the resource.  This type class is given slightly higher priority so it will be preferred to the reflective version when resolving implicits.

--- a/src/main/scala/resource/Resource.scala
+++ b/src/main/scala/resource/Resource.scala
@@ -98,14 +98,14 @@ sealed trait LowPriorityResourceImplicits {
 }
 
 sealed trait MediumPriorityResourceImplicits extends LowPriorityResourceImplicits {
-  import _root_.java.io.Closeable
+  import _root_.java.lang.AutoCloseable
 
-  implicit def closeableResource[A <: Closeable] = new Resource[A] {
+  implicit def closeableResource[A <: AutoCloseable] = new Resource[A] {
     override def close(r: A) = r.close()
     // TODO - Should we actually catch less?   What if there is a user exception not under IOException during
     // processing of a resource.   We should still close it.
     //override val possibleExceptions = List(classOf[IOException])
-    override def toString = "Resource[java.io.Closeable]"
+    override def toString = "Resource[java.lang.AutoCloseable]"
   }
   
   //Add All JDBC related handlers.

--- a/src/main/scala/resource/package.scala
+++ b/src/main/scala/resource/package.scala
@@ -7,7 +7,7 @@ package object resource {
   type ErrorHolder[A] = Either[List[Throwable],A]
   /**
    * Creates a ManagedResource for any type with a Resource type class implementation.   This includes all
-   * java.io.Closeable subclasses, and any types that have a close or dispose method.  You can also provide your own
+   * java.lang.AutoCloseable subclasses, and any types that have a close or dispose method.  You can also provide your own
    * resource type class implementations in your own scope.
    */
   def managed[A : Resource : OptManifest](opener: => A) : ManagedResource[A] = new DefaultManagedResource(opener)


### PR DESCRIPTION
Right now, Resources can be implicitly derived AutoCloseables, but (surprisingly) only through reflection, which incurs an enormous performance penalty. I'm not really sure why -- java.lang.AutoCloseable is the prescribed interface for ARM in java and has been for quite some time. I'm guessing there is some reason for keeping things this way since this change is so trivial, but I thought I'd put it up to start discussion.

Fixes https://github.com/jsuereth/scala-arm/issues/66. 

Thanks!